### PR TITLE
Update subread_featurecounts.nf

### DIFF
--- a/modules/local/subread_featurecounts.nf
+++ b/modules/local/subread_featurecounts.nf
@@ -25,8 +25,6 @@ process SUBREAD_FEATURECOUNTS {
     """
     featureCounts \\
         -L \\
-        -O \\
-        -f \\
         -g gene_id \\
         -t exon \\
         -T $task.cpus \\


### PR DESCRIPTION
Switch from exon-level to gene-level counting and disable multi-overlapping assignment to prevent double-counting of reads spanning multiple features.